### PR TITLE
Remove unused dependencies from documentation requirements

### DIFF
--- a/ginipaylib/src/doc/requirements.txt
+++ b/ginipaylib/src/doc/requirements.txt
@@ -1,6 +1,1 @@
-Jinja2==2.10.1
-MarkupSafe==0.23
-Pygments==2.0.1
-Sphinx==1.2.3
-docutils==0.12
 -e git+git@github.com:gini/gini_sphinx_theme_sdk.git#egg=gini_sphinx_theme-master

--- a/scripts/generate-sphinx-doc.sh
+++ b/scripts/generate-sphinx-doc.sh
@@ -5,7 +5,6 @@ BUILD_DIR=ginipaylib/build
 
 mkdir -p $BUILD_DIR/integration-guide
 cp -r $DOC_DIR/* $BUILD_DIR/integration-guide/
-cp scripts/requirements.txt $BUILD_DIR/integration-guide/
 cd $BUILD_DIR/integration-guide
 virtualenv ./virtualenv
 source ./virtualenv/bin/activate

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,6 +1,0 @@
-Jinja2==2.7.3
-MarkupSafe==0.23
-Pygments==2.0.1
-Sphinx==1.2.3
-docutils==0.12
--e git+git@github.com:gini/gini_sphinx_theme_sdk.git#egg=gini_sphinx_theme-master


### PR DESCRIPTION
Pygments had to be updated to 2.7.4 but that requires
python 3 and we can't use python 3 because the
`gini-sphinx-theme-vision` requires python 2.