### PR TITLE
Pia 1190 remove jcenter

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,15 +2,17 @@
 
 buildscript {
     ext.kotlin_version = '1.4.31'
+    ext.dokka_version = '1.5.0'
+
     repositories {
-        jcenter()
         google()
+        mavenCentral()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:4.1.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-        classpath "org.jetbrains.dokka:dokka-gradle-plugin:1.4.20"
-        classpath "org.jetbrains.dokka:kotlin-as-java-plugin:1.4.20"
+        classpath "org.jetbrains.dokka:dokka-gradle-plugin:$dokka_version"
+        classpath "org.jetbrains.dokka:kotlin-as-java-plugin:$dokka_version"
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
@@ -22,6 +24,5 @@ allprojects {
         maven { url = "https://dl.bintray.com/kotlin/dokka" }
         mavenCentral()
         google()
-        jcenter()
     }
 }

--- a/ginipaylib/build.gradle
+++ b/ginipaylib/build.gradle
@@ -53,7 +53,7 @@ dependencies {
     androidTestImplementation "com.android.support.test:runner:1.0.2"
     androidTestImplementation "com.android.support.test:rules:1.0.2"
 
-    dokkaHtmlPlugin 'org.jetbrains.dokka:kotlin-as-java-plugin:1.4.20'
+    dokkaHtmlPlugin "org.jetbrains.dokka:kotlin-as-java-plugin:$dokka_version"
 }
 
 apply from: file("repository.gradle")

--- a/ginipaylib/src/main/java/net/gini/android/authorization/UserCenterAPICommunicator.java
+++ b/ginipaylib/src/main/java/net/gini/android/authorization/UserCenterAPICommunicator.java
@@ -3,6 +3,7 @@ package net.gini.android.authorization;
 import android.net.Uri;
 
 import com.android.volley.RequestQueue;
+import com.android.volley.VolleyError;
 import com.android.volley.toolbox.JsonObjectRequest;
 
 import net.gini.android.GiniApiType;
@@ -15,6 +16,8 @@ import net.gini.android.requests.RetryPolicyFactory;
 import org.json.JSONException;
 import org.json.JSONObject;
 
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
 import java.util.HashMap;
 
 import bolts.Continuation;
@@ -146,10 +149,16 @@ public class UserCenterAPICommunicator {
     // Visible for testing
     Task<JSONObject> getGiniApiSessionTokenInfo(final Session giniApiSession) {
         final RequestTaskCompletionSource<JSONObject> completionSource = RequestTaskCompletionSource.newCompletionSource();
-        final String url = mBaseUrl + "oauth/check_token?token=" + giniApiSession.getAccessToken();
-        final JsonObjectRequest request =
-                new JsonObjectRequest(GET, url, null, completionSource, completionSource);
-        mRequestQueue.add(request);
+        try {
+            final String url = mBaseUrl + "oauth/check_token?token=" +
+                    URLEncoder.encode(giniApiSession.getAccessToken(), "UTF-8");
+            final JsonObjectRequest request =
+                    new JsonObjectRequest(GET, url, null, completionSource, completionSource);
+            mRequestQueue.add(request);
+        } catch (UnsupportedEncodingException e) {
+            completionSource.onErrorResponse(new VolleyError(e));
+        }
+
         return completionSource.getTask();
     }
 


### PR DESCRIPTION
Replace jcenter with maven central and update dokka to 1.5.0.

Also url encode the access token for the oauth `check_token` request. Otherwise if the access token contains reserved URL query parameter characters (like `+` or `=`) then the request fails with 400. This fixes analysis sometimes failing after changing the email domain.